### PR TITLE
Add floodfill algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ==========
 
 - Add `algorithms::distance_transform` module with functions for calculating distance transforms
+- Add `algorithms::floodfill` module with functions for calculating flood-fills
+- Add `LargeCostMatrix` struct for cost matrices that need more than `u8` sized value data
 
 0.21.1 (2023-05-15)
 ===================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ all-features = true
 screeps-game-api = "0.21"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_with = "3.8.1"
 
 [dev-dependencies]
 assert_approx_eq = "1.1"

--- a/src/algorithms/floodfill.rs
+++ b/src/algorithms/floodfill.rs
@@ -27,7 +27,11 @@ pub fn get_obstacles_lcm_from_terrain(room_terrain: &LocalRoomTerrain) -> LocalC
 ///
 /// The obstacles Cost Matrix should have u8::MAX set on all positions that are
 /// obstacles, and 0 everywhere else.
-pub fn numerical_floodfill(origins: &Vec<RoomXY>, obstacles: &LocalCostMatrix, max_distance: u16) -> LargeCostMatrix {
+pub fn numerical_floodfill(
+    origins: &Vec<RoomXY>,
+    obstacles: &LocalCostMatrix,
+    max_distance: u16,
+) -> LargeCostMatrix {
     let mut output_cm = LargeCostMatrix::new_with_default(u16::MAX);
 
     let mut queue: VecDeque<RoomXY> = VecDeque::new();

--- a/src/algorithms/floodfill.rs
+++ b/src/algorithms/floodfill.rs
@@ -56,19 +56,17 @@ pub fn numerical_floodfill(
             .filter(|position| obstacles.get(*position) == 0)
             .for_each(|position| {
                 // Only process neighbors that haven't been seen yet
-                if seen.get(position) == 0 {
-                    if neighbor_distance <= max_distance {
-                        queue.push_back(position);
-                        seen.set(position, 1);
-                        output_cm.set(position, neighbor_distance);
-                    }
+                if seen.get(position) == 0 && neighbor_distance <= max_distance {
+                    queue.push_back(position);
+                    seen.set(position, 1);
+                    output_cm.set(position, neighbor_distance);
                 }
             });
     }
 
     // Process all entries in the queue
     let mut max_queue_length = 0;
-    while queue.len() > 0 {
+    while !queue.is_empty() {
         let queue_length = queue.len();
         if queue_length > max_queue_length {
             max_queue_length = queue_length;
@@ -89,15 +87,13 @@ pub fn numerical_floodfill(
                 .filter(|position| obstacles.get(*position) == 0)
                 .for_each(|position| {
                     // Only process neighbors that haven't been seen yet
-                    if seen.get(position) == 0 {
-                        if neighbor_distance <= max_distance {
-                            queue.push_back(position);
-                            seen.set(position, 1);
+                    if seen.get(position) == 0 && neighbor_distance <= max_distance {
+                        queue.push_back(position);
+                        seen.set(position, 1);
 
-                            // Only update the position distance if it hasn't already been set
-                            if output_cm.get(position) == u16::MAX {
-                                output_cm.set(position, neighbor_distance);
-                            }
+                        // Only update the position distance if it hasn't already been set
+                        if output_cm.get(position) == u16::MAX {
+                            output_cm.set(position, neighbor_distance);
                         }
                     }
                 });

--- a/src/algorithms/floodfill.rs
+++ b/src/algorithms/floodfill.rs
@@ -1,0 +1,113 @@
+use std::collections::VecDeque;
+
+use screeps::constants::Direction;
+use screeps::local::{LocalCostMatrix, LocalRoomTerrain, RoomXY};
+use crate::large_cost_matrix::LargeCostMatrix;
+
+
+/// Creates a LocalCostMatrix from LocalRoomTerrain, such that all the positions
+/// which are Walls will have the value u8::MAX, and all other positions will
+/// have a value of 0.
+pub fn get_obstacles_lcm_from_terrain(room_terrain: &LocalRoomTerrain) -> LocalCostMatrix {
+  let mut obstacles = LocalCostMatrix::new();
+  for (xy, cm_val) in obstacles.iter_mut() {
+      *cm_val = match room_terrain.get_xy(xy) {
+          screeps::constants::Terrain::Wall => u8::MAX,
+          _ => 0,
+      };
+  }
+
+  obstacles
+}
+
+/// Takes a Vec of origin locations to start the floodfill from, and a Cost Matrix of obstacles,
+/// and produces a `LargeCostMatrix` with distances for all positions that can be reached from the origin points.
+///
+/// The obstacles Cost Matrix should have u8::MAX set on all positions that are obstacles, and 0 everywhere else.
+pub fn numerical_floodfill(origins: &Vec<RoomXY>, obstacles: &LocalCostMatrix) -> LargeCostMatrix {
+  let mut output_cm = LargeCostMatrix::new_with_default(u16::MAX);
+
+  let mut queue: VecDeque<RoomXY> = VecDeque::new();
+  let mut seen = LocalCostMatrix::new();
+
+  // Add all the valid neighbors of the origin positions to the queue to be visited
+  for current_position in origins {
+    // The current origin position is trivially reachable from the set of origin positions
+    output_cm.set(*current_position, 0);
+
+    // We've visited this origin position
+    seen.set(*current_position, 1);
+
+    // Check each neighbor of the current origin position for validity and add it to the queue to be checked
+    Direction::iter()
+      .filter_map(|dir| current_position.checked_add_direction(*dir))
+      .filter(|position| obstacles.get(*position) == 0)
+      .for_each(|position| {
+          // Only process neighbors that haven't been seen yet
+        if seen.get(position) == 0 {
+          queue.push_back(position);
+          seen.set(position, 1);
+          output_cm.set(position, 1);
+        }
+      });
+  }
+
+  // Process all entries in the queue
+  let mut max_queue_length = 0;
+  while queue.len() > 0 {
+    let queue_length = queue.len();
+    if queue_length > max_queue_length {
+      max_queue_length = queue_length;
+    }
+
+    // Pop the next entry off the queue
+    if let Some(current_position) = queue.pop_front() {
+
+      // Mark current position as visited
+      seen.set(current_position, 1);
+
+      // Get the current distance value to increment for unvisited neighbors
+      let current_distance = output_cm.get(current_position);
+      let neighbor_distance = current_distance + 1;
+
+      // Get list of valid neighbors and add them to the queue to be visited
+      Direction::iter()
+        .filter_map(|dir| current_position.checked_add_direction(*dir))
+        .filter(|position| obstacles.get(*position) == 0)
+        .for_each(|position| {
+          // Only process neighbors that haven't been seen yet
+          if seen.get(position) == 0 {
+            queue.push_back(position);
+            seen.set(position, 1);
+
+            // Only update the position distance if it hasn't already been set
+            if output_cm.get(position) == u16::MAX {
+              output_cm.set(position, neighbor_distance);
+            }
+          }
+        });
+    };
+  }
+
+  output_cm
+}
+
+/// Takes a Vec of origin locations to start the floodfill from, and a Cost Matrix of obstacles,
+/// and produces a Cost Matrix with 1 values for all positions that can be reached from the origin points,
+/// and 0 values everywhere else.
+///
+/// The obstacles Cost Matrix should have u8::MAX set on all positions that are obstacles, and 0 everywhere else.
+pub fn reachability_floodfill(origins: &Vec<RoomXY>, obstacles: &LocalCostMatrix) -> LocalCostMatrix {
+  let ff_lg_cm = numerical_floodfill(origins, obstacles);
+
+  let mut ret_cm = LocalCostMatrix::new();
+
+  for (xy, cm_val) in ret_cm.iter_mut() {
+      *cm_val = match ff_lg_cm.get(xy) {
+          u16::MAX => 0,
+          _ => 1,
+      };
+  }
+
+  ret_cm
+}

--- a/src/algorithms/floodfill.rs
+++ b/src/algorithms/floodfill.rs
@@ -1,113 +1,123 @@
 use std::collections::VecDeque;
 
-use screeps::constants::Direction;
-use screeps::local::{LocalCostMatrix, LocalRoomTerrain, RoomXY};
 use crate::large_cost_matrix::LargeCostMatrix;
-
+use screeps::{
+    constants::Direction,
+    local::{LocalCostMatrix, LocalRoomTerrain, RoomXY},
+};
 
 /// Creates a LocalCostMatrix from LocalRoomTerrain, such that all the positions
 /// which are Walls will have the value u8::MAX, and all other positions will
 /// have a value of 0.
 pub fn get_obstacles_lcm_from_terrain(room_terrain: &LocalRoomTerrain) -> LocalCostMatrix {
-  let mut obstacles = LocalCostMatrix::new();
-  for (xy, cm_val) in obstacles.iter_mut() {
-      *cm_val = match room_terrain.get_xy(xy) {
-          screeps::constants::Terrain::Wall => u8::MAX,
-          _ => 0,
-      };
-  }
-
-  obstacles
-}
-
-/// Takes a Vec of origin locations to start the floodfill from, and a Cost Matrix of obstacles,
-/// and produces a `LargeCostMatrix` with distances for all positions that can be reached from the origin points.
-///
-/// The obstacles Cost Matrix should have u8::MAX set on all positions that are obstacles, and 0 everywhere else.
-pub fn numerical_floodfill(origins: &Vec<RoomXY>, obstacles: &LocalCostMatrix) -> LargeCostMatrix {
-  let mut output_cm = LargeCostMatrix::new_with_default(u16::MAX);
-
-  let mut queue: VecDeque<RoomXY> = VecDeque::new();
-  let mut seen = LocalCostMatrix::new();
-
-  // Add all the valid neighbors of the origin positions to the queue to be visited
-  for current_position in origins {
-    // The current origin position is trivially reachable from the set of origin positions
-    output_cm.set(*current_position, 0);
-
-    // We've visited this origin position
-    seen.set(*current_position, 1);
-
-    // Check each neighbor of the current origin position for validity and add it to the queue to be checked
-    Direction::iter()
-      .filter_map(|dir| current_position.checked_add_direction(*dir))
-      .filter(|position| obstacles.get(*position) == 0)
-      .for_each(|position| {
-          // Only process neighbors that haven't been seen yet
-        if seen.get(position) == 0 {
-          queue.push_back(position);
-          seen.set(position, 1);
-          output_cm.set(position, 1);
-        }
-      });
-  }
-
-  // Process all entries in the queue
-  let mut max_queue_length = 0;
-  while queue.len() > 0 {
-    let queue_length = queue.len();
-    if queue_length > max_queue_length {
-      max_queue_length = queue_length;
+    let mut obstacles = LocalCostMatrix::new();
+    for (xy, cm_val) in obstacles.iter_mut() {
+        *cm_val = match room_terrain.get_xy(xy) {
+            screeps::constants::Terrain::Wall => u8::MAX,
+            _ => 0,
+        };
     }
 
-    // Pop the next entry off the queue
-    if let Some(current_position) = queue.pop_front() {
-
-      // Mark current position as visited
-      seen.set(current_position, 1);
-
-      // Get the current distance value to increment for unvisited neighbors
-      let current_distance = output_cm.get(current_position);
-      let neighbor_distance = current_distance + 1;
-
-      // Get list of valid neighbors and add them to the queue to be visited
-      Direction::iter()
-        .filter_map(|dir| current_position.checked_add_direction(*dir))
-        .filter(|position| obstacles.get(*position) == 0)
-        .for_each(|position| {
-          // Only process neighbors that haven't been seen yet
-          if seen.get(position) == 0 {
-            queue.push_back(position);
-            seen.set(position, 1);
-
-            // Only update the position distance if it hasn't already been set
-            if output_cm.get(position) == u16::MAX {
-              output_cm.set(position, neighbor_distance);
-            }
-          }
-        });
-    };
-  }
-
-  output_cm
+    obstacles
 }
 
-/// Takes a Vec of origin locations to start the floodfill from, and a Cost Matrix of obstacles,
-/// and produces a Cost Matrix with 1 values for all positions that can be reached from the origin points,
-/// and 0 values everywhere else.
+/// Takes a Vec of origin locations to start the floodfill from, and a Cost
+/// Matrix of obstacles, and produces a `LargeCostMatrix` with distances for all
+/// positions that can be reached from the origin points.
 ///
-/// The obstacles Cost Matrix should have u8::MAX set on all positions that are obstacles, and 0 everywhere else.
-pub fn reachability_floodfill(origins: &Vec<RoomXY>, obstacles: &LocalCostMatrix) -> LocalCostMatrix {
-  let ff_lg_cm = numerical_floodfill(origins, obstacles);
+/// The obstacles Cost Matrix should have u8::MAX set on all positions that are
+/// obstacles, and 0 everywhere else.
+pub fn numerical_floodfill(origins: &Vec<RoomXY>, obstacles: &LocalCostMatrix) -> LargeCostMatrix {
+    let mut output_cm = LargeCostMatrix::new_with_default(u16::MAX);
 
-  let mut ret_cm = LocalCostMatrix::new();
+    let mut queue: VecDeque<RoomXY> = VecDeque::new();
+    let mut seen = LocalCostMatrix::new();
 
-  for (xy, cm_val) in ret_cm.iter_mut() {
-      *cm_val = match ff_lg_cm.get(xy) {
-          u16::MAX => 0,
-          _ => 1,
-      };
-  }
+    // Add all the valid neighbors of the origin positions to the queue to be
+    // visited
+    for current_position in origins {
+        // The current origin position is trivially reachable from the set of origin
+        // positions
+        output_cm.set(*current_position, 0);
 
-  ret_cm
+        // We've visited this origin position
+        seen.set(*current_position, 1);
+
+        // Check each neighbor of the current origin position for validity and add it to
+        // the queue to be checked
+        Direction::iter()
+            .filter_map(|dir| current_position.checked_add_direction(*dir))
+            .filter(|position| obstacles.get(*position) == 0)
+            .for_each(|position| {
+                // Only process neighbors that haven't been seen yet
+                if seen.get(position) == 0 {
+                    queue.push_back(position);
+                    seen.set(position, 1);
+                    output_cm.set(position, 1);
+                }
+            });
+    }
+
+    // Process all entries in the queue
+    let mut max_queue_length = 0;
+    while queue.len() > 0 {
+        let queue_length = queue.len();
+        if queue_length > max_queue_length {
+            max_queue_length = queue_length;
+        }
+
+        // Pop the next entry off the queue
+        if let Some(current_position) = queue.pop_front() {
+            // Mark current position as visited
+            seen.set(current_position, 1);
+
+            // Get the current distance value to increment for unvisited neighbors
+            let current_distance = output_cm.get(current_position);
+            let neighbor_distance = current_distance + 1;
+
+            // Get list of valid neighbors and add them to the queue to be visited
+            Direction::iter()
+                .filter_map(|dir| current_position.checked_add_direction(*dir))
+                .filter(|position| obstacles.get(*position) == 0)
+                .for_each(|position| {
+                    // Only process neighbors that haven't been seen yet
+                    if seen.get(position) == 0 {
+                        queue.push_back(position);
+                        seen.set(position, 1);
+
+                        // Only update the position distance if it hasn't already been set
+                        if output_cm.get(position) == u16::MAX {
+                            output_cm.set(position, neighbor_distance);
+                        }
+                    }
+                });
+        };
+    }
+
+    output_cm
+}
+
+/// Takes a Vec of origin locations to start the floodfill from, and a Cost
+/// Matrix of obstacles, and produces a Cost Matrix with 1 values for all
+/// positions that can be reached from the origin points, and 0 values
+/// everywhere else.
+///
+/// The obstacles Cost Matrix should have u8::MAX set on all positions that are
+/// obstacles, and 0 everywhere else.
+pub fn reachability_floodfill(
+    origins: &Vec<RoomXY>,
+    obstacles: &LocalCostMatrix,
+) -> LocalCostMatrix {
+    let ff_lg_cm = numerical_floodfill(origins, obstacles);
+
+    let mut ret_cm = LocalCostMatrix::new();
+
+    for (xy, cm_val) in ret_cm.iter_mut() {
+        *cm_val = match ff_lg_cm.get(xy) {
+            u16::MAX => 0,
+            _ => 1,
+        };
+    }
+
+    ret_cm
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,1 +1,2 @@
 pub mod distance_transform;
+pub mod floodfill;

--- a/src/large_cost_matrix.rs
+++ b/src/large_cost_matrix.rs
@@ -1,0 +1,195 @@
+use std::ops::{Index, IndexMut};
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use screeps::{
+    constants::ROOM_SIZE,
+    objects::CostMatrix,
+    traits::{CostMatrixGet, CostMatrixSet},
+};
+
+use screeps::local::{linear_index_to_xy, xy_to_linear_index, LocalCostMatrix, Position, RoomXY};
+
+pub const ROOM_AREA: usize = ROOM_SIZE as usize * ROOM_SIZE as usize;
+
+/// A matrix of pathing costs for a room, stored in Rust memory. Stores
+/// u16 values, so it can hold significantly more data in any particular
+/// position compared to the default `CostMatrix`.
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LargeCostMatrix {
+    #[serde_as(as = "[_; ROOM_AREA]")]
+    bits: [u16; ROOM_AREA],
+}
+
+impl Default for LargeCostMatrix {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LargeCostMatrix {
+    #[inline]
+    pub const fn new() -> Self {
+        LargeCostMatrix {
+            bits: [0; ROOM_AREA],
+        }
+    }
+    #[inline]
+    pub const fn new_with_default(default: u16) -> Self {
+        LargeCostMatrix {
+            bits: [default; ROOM_AREA],
+        }
+    }
+
+    // # Notes
+    // This method does no bounds checking for the passed-in `RoomXY`, you may use
+    // `RoomXY::unchecked_new` to skip all bounds checking.
+    #[inline]
+    pub fn set(&mut self, xy: RoomXY, val: u16) {
+        self[xy] = val;
+    }
+
+    // # Notes
+    // This method does no bounds checking for the passed-in `RoomXY`, you may use
+    // `RoomXY::unchecked_new` to skip all bounds checking.
+    #[inline]
+    pub fn get(&self, xy: RoomXY) -> u16 {
+        self[xy]
+    }
+
+    pub const fn get_bits(&self) -> &[u16; ROOM_AREA] {
+        &self.bits
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (RoomXY, u16)> + '_ {
+        self.bits
+            .iter()
+            .enumerate()
+            .map(|(idx, &val)| (linear_index_to_xy(idx), val))
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (RoomXY, &mut u16)> {
+        self.bits
+            .iter_mut()
+            .enumerate()
+            .map(|(idx, val)| (linear_index_to_xy(idx), val))
+    }
+}
+
+impl From<LargeCostMatrix> for Vec<u16> {
+    /// Returns a vector of bits length ROOM_AREA, where each position is
+    /// `idx = ((x * ROOM_SIZE) + y)`.
+    #[inline]
+    fn from(lcm: LargeCostMatrix) -> Vec<u16> {
+        lcm.bits.into()
+    }
+}
+
+impl From<&LargeCostMatrix> for Vec<u16> {
+    fn from(lcm: &LargeCostMatrix) -> Vec<u16> {
+        lcm.bits.into()
+    }
+}
+
+impl From<&CostMatrix> for LargeCostMatrix {
+    fn from(js_matrix: &CostMatrix) -> Self {
+        let mut bits: [u16; ROOM_AREA] = [0; ROOM_AREA];
+        js_matrix
+            .get_bits()
+            .to_vec()
+            .iter()
+            .enumerate()
+            .for_each(|(idx, &val)| bits[idx] = val.into());
+
+        LargeCostMatrix { bits }
+    }
+}
+
+impl Index<RoomXY> for LargeCostMatrix {
+    type Output = u16;
+
+    fn index(&self, xy: RoomXY) -> &Self::Output {
+        // SAFETY: RoomXY is always a valid coordinate.
+        unsafe { self.bits.get_unchecked(xy_to_linear_index(xy)) }
+    }
+}
+
+impl IndexMut<RoomXY> for LargeCostMatrix {
+    fn index_mut(&mut self, xy: RoomXY) -> &mut Self::Output {
+        // SAFETY: RoomXY is always a valid coordinate.
+        unsafe { self.bits.get_unchecked_mut(xy_to_linear_index(xy)) }
+    }
+}
+
+impl Index<Position> for LargeCostMatrix {
+    type Output = u16;
+
+    fn index(&self, idx: Position) -> &Self::Output {
+        &self[RoomXY::from(idx)]
+    }
+}
+
+impl IndexMut<Position> for LargeCostMatrix {
+    fn index_mut(&mut self, idx: Position) -> &mut Self::Output {
+        &mut self[RoomXY::from(idx)]
+    }
+}
+
+impl CostMatrixSet for LargeCostMatrix {
+    fn set_xy(&mut self, xy: RoomXY, cost: u8) {
+        LargeCostMatrix::set(self, xy, cost as u16);
+    }
+}
+
+impl CostMatrixGet for LargeCostMatrix {
+    fn get_xy(&mut self, xy: RoomXY) -> u8 {
+        match u8::try_from(LargeCostMatrix::get(self, xy)) {
+            Ok(var) => var,
+            Err(_) => u8::MAX,
+        }
+    }
+}
+
+impl From<LargeCostMatrix> for LocalCostMatrix {
+    fn from(lcm: LargeCostMatrix) -> LocalCostMatrix {
+        let mut ret_lcm = LocalCostMatrix::new();
+
+        lcm.bits
+            .to_vec()
+            .iter()
+            .enumerate()
+            .for_each(|(idx, &val)| ret_lcm.set(linear_index_to_xy(idx), val.try_into().unwrap_or(u8::MAX)));
+
+        ret_lcm
+    }
+}
+
+impl From<&LargeCostMatrix> for LocalCostMatrix {
+    fn from(lcm: &LargeCostMatrix) -> LocalCostMatrix {
+        let mut ret_lcm = LocalCostMatrix::new();
+
+        lcm.bits
+            .to_vec()
+            .iter()
+            .enumerate()
+            .for_each(|(idx, &val)| ret_lcm.set(linear_index_to_xy(idx), val.try_into().unwrap_or(u8::MAX)));
+
+        ret_lcm
+    }
+}
+
+impl From<LargeCostMatrix> for CostMatrix {
+    fn from(lcm: LargeCostMatrix) -> CostMatrix {
+        let mut bits: [u8; ROOM_AREA] = [0; ROOM_AREA];
+        lcm.bits
+            .to_vec()
+            .iter()
+            .enumerate()
+            .for_each(|(idx, &val)| bits[idx] = val.try_into().unwrap_or(u8::MAX));
+
+        CostMatrix::new_from_bits(&bits)
+    }
+}

--- a/src/large_cost_matrix.rs
+++ b/src/large_cost_matrix.rs
@@ -161,7 +161,9 @@ impl From<LargeCostMatrix> for LocalCostMatrix {
             .to_vec()
             .iter()
             .enumerate()
-            .for_each(|(idx, &val)| ret_lcm.set(linear_index_to_xy(idx), val.try_into().unwrap_or(u8::MAX)));
+            .for_each(|(idx, &val)| {
+                ret_lcm.set(linear_index_to_xy(idx), val.try_into().unwrap_or(u8::MAX))
+            });
 
         ret_lcm
     }
@@ -175,7 +177,9 @@ impl From<&LargeCostMatrix> for LocalCostMatrix {
             .to_vec()
             .iter()
             .enumerate()
-            .for_each(|(idx, &val)| ret_lcm.set(linear_index_to_xy(idx), val.try_into().unwrap_or(u8::MAX)));
+            .for_each(|(idx, &val)| {
+                ret_lcm.set(linear_index_to_xy(idx), val.try_into().unwrap_or(u8::MAX))
+            });
 
         ret_lcm
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod algorithms;
+pub mod large_cost_matrix;
 pub mod math;
 pub mod offline_map;
 pub mod sparse_cost_matrix;
-pub mod large_cost_matrix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod algorithms;
 pub mod math;
 pub mod offline_map;
 pub mod sparse_cost_matrix;
+pub mod large_cost_matrix;


### PR DESCRIPTION
This PR adds floodfill algorithms, as well as an associated `LargeCostMatrix` struct to allow for `u16` sized values for each position.

This is dependent on unreleased updates currently merged into the `main` branch of `screeps-game-api`, and will need the dependency version bumped once those updates are released.