### PR TITLE
Add iterators over various `RoomXY` and `RoomCoordinate` ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Add iterators over various `RoomXY` and `RoomCoordinate` ranges
+
 0.22.0 (2024-08-27)
 ===================
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ assert_approx_eq = "1.1"
 
 [features]
 default = []
+
+[profile.release]
+lto = true

--- a/benches/room_xy_iters.rs
+++ b/benches/room_xy_iters.rs
@@ -1,0 +1,144 @@
+#![feature(test)]
+extern crate test;
+
+#[cfg(test)]
+mod benches {
+    use chrono::Local;
+    use screeps::local::{LocalCostMatrix, RoomCoordinate, RoomXY};
+    use screeps_utils::{room_coordinate::*, room_xy::*};
+    use test::{black_box, Bencher};
+
+    fn make_xy(x: u8, y: u8) -> RoomXY {
+        RoomXY {
+            x: RoomCoordinate::new(x).unwrap(),
+            y: RoomCoordinate::new(y).unwrap(),
+        }
+    }
+
+    #[bench]
+    fn bench_full_grid_iter_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        b.iter(|| {
+            GridIter::new(
+                black_box(make_xy(0, 0)),
+                black_box(make_xy(49, 49)),
+                Order::XMajor,
+            )
+            .for_each(|xy| black_box(&mut cm).set(xy, 255));
+        });
+    }
+
+    #[bench]
+    fn bench_full_for_loop_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        b.iter(|| {
+            for x in black_box(0)..black_box(50) {
+                let x = RoomCoordinate::new(x).unwrap();
+                for y in black_box(0)..black_box(50) {
+                    let y = RoomCoordinate::new(y).unwrap();
+                    black_box(&mut cm).set(RoomXY { x, y }, 255);
+                }
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_full_range_iter_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        let zero = RoomCoordinate::new(0).unwrap();
+        let max = RoomCoordinate::new(49).unwrap();
+        b.iter(|| {
+            for x in range_inclusive(black_box(zero), black_box(max)) {
+                for y in range_inclusive(black_box(zero), black_box(max)) {
+                    black_box(&mut cm).set(RoomXY { x, y }, 255);
+                }
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_chebyshev_iter_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        let centre = make_xy(10, 10);
+        b.iter(|| {
+            chebyshev_range_iter(black_box(centre), 3)
+                .for_each(|xy| black_box(&mut cm).set(xy, 255));
+        });
+    }
+
+    #[bench]
+    fn bench_chebyshev_saturating_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        let centre = make_xy(10, 10);
+        b.iter(|| {
+            let min_x = black_box(centre).x.saturating_add(-3);
+            let max_x = black_box(centre).x.saturating_add(3);
+            let min_y = black_box(centre).y.saturating_add(-3);
+            let max_y = black_box(centre).y.saturating_add(3);
+            for x in range_inclusive(min_x, max_x) {
+                for y in range_inclusive(min_y, max_y) {
+                    black_box(&mut cm).set(RoomXY { x, y }, 255);
+                }
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_chebyshev_checked_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        let centre = make_xy(10, 10);
+        b.iter(|| {
+            for x in (-3..=3).filter_map(|offset| black_box(centre).x.checked_add(offset)) {
+                for y in (-3..=3).filter_map(|offset| black_box(centre).y.checked_add(offset)) {
+                    black_box(&mut cm).set(RoomXY { x, y }, 255);
+                }
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_manhattan_iter_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        let centre = make_xy(10, 10);
+        b.iter(|| {
+            manhattan_range_iter(black_box(centre), 3)
+                .for_each(|xy| black_box(&mut cm).set(xy, 255));
+        });
+    }
+
+    #[bench]
+    fn bench_manhattan_saturating_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        let centre = make_xy(10, 10);
+        b.iter(|| {
+            let min_x = black_box(centre).x.saturating_add(-3);
+            let max_x = black_box(centre).x.saturating_add(3);
+            for (x, offset) in range_inclusive(min_x, max_x).zip(-3_i8..=3) {
+                let y_radius = 3 - offset.abs();
+                let min_y = black_box(centre).y.saturating_add(-y_radius);
+                let max_y = black_box(centre).y.saturating_add(y_radius);
+                for y in range_inclusive(min_y, max_y) {
+                    black_box(&mut cm).set(RoomXY { x, y }, 255);
+                }
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_manhattan_checked_cm_set(b: &mut Bencher) {
+        let mut cm = LocalCostMatrix::new();
+        let centre = make_xy(10, 10);
+        b.iter(|| {
+            for (x, offset) in (-3..=3)
+                .filter_map(|offset| black_box(centre).x.checked_add(offset).map(|x| (x, offset)))
+            {
+                let y_radius = 3 - offset.abs();
+                for y in (-y_radius..=y_radius)
+                    .filter_map(|offset| black_box(centre).y.checked_add(offset))
+                {
+                    black_box(&mut cm).set(RoomXY { x, y }, 255);
+                }
+            }
+        })
+    }
+}

--- a/benches/room_xy_iters.rs
+++ b/benches/room_xy_iters.rs
@@ -3,7 +3,6 @@ extern crate test;
 
 #[cfg(test)]
 mod benches {
-    use chrono::Local;
     use screeps::local::{LocalCostMatrix, RoomCoordinate, RoomXY};
     use screeps_utils::{room_coordinate::*, room_xy::*};
     use test::{black_box, Bencher};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,6 @@ pub mod map;
 pub mod math;
 pub mod object;
 pub mod offline_map;
-pub mod room_xy;
 pub mod room_coordinate;
+pub mod room_xy;
 pub mod sparse_cost_matrix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod map;
 pub mod math;
 pub mod object;
 pub mod offline_map;
+pub mod room_xy;
 pub mod sparse_cost_matrix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ pub mod math;
 pub mod object;
 pub mod offline_map;
 pub mod room_xy;
+pub mod room_coordinate;
 pub mod sparse_cost_matrix;

--- a/src/room_coordinate.rs
+++ b/src/room_coordinate.rs
@@ -1,0 +1,17 @@
+use screeps::local::RoomCoordinate;
+
+pub fn range_inclusive(
+    a: RoomCoordinate,
+    b: RoomCoordinate,
+) -> impl DoubleEndedIterator<Item = RoomCoordinate> {
+    // SAFETY: x \in [a.0, b.0], so it's in-bounds.
+    (a.u8()..=b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
+}
+
+pub fn range_exclusive(
+    a: RoomCoordinate,
+    b: RoomCoordinate,
+) -> impl DoubleEndedIterator<Item = RoomCoordinate> {
+    // SAFETY: x \in [a.0, b.0), so it's in-bounds.
+    (a.u8()..b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
+}

--- a/src/room_coordinate.rs
+++ b/src/room_coordinate.rs
@@ -1,6 +1,7 @@
 use screeps::local::RoomCoordinate;
 
-/// Iterate over the range of [`RoomCoordinate`]s from `a` to `b`, including both endpoints.
+/// Iterate over the range of [`RoomCoordinate`]s from `a` to `b`, including
+/// both endpoints.
 ///
 /// Safe to call even when `a > b`, will just yield an empty range.
 ///
@@ -10,9 +11,12 @@ use screeps::local::RoomCoordinate;
 /// use screeps::local::RoomCoordinate;
 /// use screeps_utils::room_coordinate::range_inclusive;
 ///
-/// let coords: Vec<u8> = range_inclusive(RoomCoordinate::new(0).unwrap(), RoomCoordinate::new(10).unwrap())
-///     .map(|coord| coord.u8())
-///     .collect();
+/// let coords: Vec<u8> = range_inclusive(
+///     RoomCoordinate::new(0).unwrap(),
+///     RoomCoordinate::new(10).unwrap(),
+/// )
+/// .map(|coord| coord.u8())
+/// .collect();
 /// assert_eq!(coords, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10_u8]);
 /// ```
 pub fn range_inclusive(
@@ -23,7 +27,8 @@ pub fn range_inclusive(
     (a.u8()..=b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
 }
 
-/// Iterate over the range of [`RoomCoordinates`]s from `a` to `b`, excluding both endpoints.
+/// Iterate over the range of [`RoomCoordinates`]s from `a` to `b`, excluding
+/// both endpoints.
 ///
 /// Safe to call even when `a >= b`, will just yield an empty range.
 ///
@@ -33,15 +38,21 @@ pub fn range_inclusive(
 /// use screeps::local::RoomCoordinate;
 /// use screeps_utils::room_coordinate::range_exclusive;
 ///
-/// let coords: Vec<u8> = range_exclusive(RoomCoordinate::new(0).unwrap(), RoomCoordinate::new(10).unwrap())
-///     .map(|coord| coord.u8())
-///     .collect();
+/// let coords: Vec<u8> = range_exclusive(
+///     RoomCoordinate::new(0).unwrap(),
+///     RoomCoordinate::new(10).unwrap(),
+/// )
+/// .map(|coord| coord.u8())
+/// .collect();
 /// assert_eq!(coords, [1, 2, 3, 4, 5, 6, 7, 8, 9_u8]);
 ///
 /// // Works for empty ranges too.
-/// let coords: Vec<u8> = range_exclusive(RoomCoordinate::new(0).unwrap(), RoomCoordinate::new(1).unwrap())
-///     .map(|coord| coord.u8())
-///     .collect();
+/// let coords: Vec<u8> = range_exclusive(
+///     RoomCoordinate::new(0).unwrap(),
+///     RoomCoordinate::new(1).unwrap(),
+/// )
+/// .map(|coord| coord.u8())
+/// .collect();
 /// assert!(coords.is_empty());
 /// ```
 pub fn range_exclusive(

--- a/src/room_coordinate.rs
+++ b/src/room_coordinate.rs
@@ -1,5 +1,20 @@
 use screeps::local::RoomCoordinate;
 
+/// Iterate over the range of `RoomCoordinate`s from `a` to `b`, including both endpoints.
+///
+/// Safe to call even when a > b, will just yield an empty range.
+///
+/// # Example
+///
+/// ```
+/// use screeps::local::RoomCoordinate;
+/// use screeps_utils::room_coordinate::range_inclusive;
+///
+/// let coords: Vec<u8> = range_inclusive(RoomCoordinate::new(0).unwrap(), RoomCoordinate::new(10).unwrap())
+///     .map(|coord| coord.u8())
+///     .collect();
+/// assert_eq!(coords, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10_u8]);
+/// ```
 pub fn range_inclusive(
     a: RoomCoordinate,
     b: RoomCoordinate,
@@ -8,10 +23,94 @@ pub fn range_inclusive(
     (a.u8()..=b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
 }
 
+/// Iterate over the range of `RoomCoordinates`s from `a` to `b`, excluding both endpoints.
+///
+/// Safe to call even when a >= b, will just yield an empty range.
+///
+/// # Example
+///
+/// ```
+/// use screeps::local::RoomCoordinate;
+/// use screeps_utils::room_coordinate::range_exclusive;
+///
+/// let coords: Vec<u8> = range_exclusive(RoomCoordinate::new(0).unwrap(), RoomCoordinate::new(10).unwrap())
+///     .map(|coord| coord.u8())
+///     .collect();
+/// assert_eq!(coords, [1, 2, 3, 4, 5, 6, 7, 8, 9_u8]);
+///
+/// // Works for empty ranges too.
+/// let coords: Vec<u8> = range_exclusive(RoomCoordinate::new(0).unwrap(), RoomCoordinate::new(1).unwrap())
+///     .map(|coord| coord.u8())
+///     .collect();
+/// assert!(coords.is_empty());
+/// ```
 pub fn range_exclusive(
     a: RoomCoordinate,
     b: RoomCoordinate,
 ) -> impl DoubleEndedIterator<Item = RoomCoordinate> {
-    // SAFETY: x \in [a.0, b.0), so it's in-bounds.
-    (a.u8()..b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
+    // SAFETY: x \in (a.0, b.0), so it's in-bounds.
+    (a.u8() + 1..b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_inclusive_reverse() {
+        let coords: Vec<u8> = range_inclusive(
+            RoomCoordinate::new(10).unwrap(),
+            RoomCoordinate::new(20).unwrap(),
+        )
+        .map(|coord| coord.u8())
+        .rev()
+        .collect();
+        assert_eq!(coords, [20_u8, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10]);
+    }
+
+    #[test]
+    fn test_inclusive_a_geq_b() {
+        let coords: Vec<_> = range_inclusive(
+            RoomCoordinate::new(30).unwrap(),
+            RoomCoordinate::new(30).unwrap(),
+        )
+        .collect();
+        assert_eq!(coords, [RoomCoordinate::new(30).unwrap()]);
+
+        let coords: Vec<_> = range_inclusive(
+            RoomCoordinate::new(1).unwrap(),
+            RoomCoordinate::new(0).unwrap(),
+        )
+        .collect();
+        assert!(coords.is_empty());
+    }
+
+    #[test]
+    fn test_exclusive_reverse() {
+        let coords: Vec<u8> = range_exclusive(
+            RoomCoordinate::new(10).unwrap(),
+            RoomCoordinate::new(20).unwrap(),
+        )
+        .map(|coord| coord.u8())
+        .rev()
+        .collect();
+        assert_eq!(coords, [19_u8, 18, 17, 16, 15, 14, 13, 12, 11]);
+    }
+
+    #[test]
+    fn test_exclusive_a_geq_b() {
+        let coords: Vec<_> = range_exclusive(
+            RoomCoordinate::new(49).unwrap(),
+            RoomCoordinate::new(49).unwrap(),
+        )
+        .collect();
+        assert!(coords.is_empty());
+
+        let coords: Vec<_> = range_exclusive(
+            RoomCoordinate::new(49).unwrap(),
+            RoomCoordinate::new(48).unwrap(),
+        )
+        .collect();
+        assert!(coords.is_empty());
+    }
 }

--- a/src/room_coordinate.rs
+++ b/src/room_coordinate.rs
@@ -27,7 +27,7 @@ pub fn range_inclusive(
     (a.u8()..=b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
 }
 
-/// Iterate over the range of [`RoomCoordinates`]s from `a` to `b`, excluding
+/// Iterate over the range of [`RoomCoordinate`]s from `a` to `b`, excluding
 /// both endpoints.
 ///
 /// Safe to call even when `a >= b`, will just yield an empty range.

--- a/src/room_coordinate.rs
+++ b/src/room_coordinate.rs
@@ -1,8 +1,8 @@
 use screeps::local::RoomCoordinate;
 
-/// Iterate over the range of `RoomCoordinate`s from `a` to `b`, including both endpoints.
+/// Iterate over the range of [`RoomCoordinate`]s from `a` to `b`, including both endpoints.
 ///
-/// Safe to call even when a > b, will just yield an empty range.
+/// Safe to call even when `a > b`, will just yield an empty range.
 ///
 /// # Example
 ///
@@ -23,9 +23,9 @@ pub fn range_inclusive(
     (a.u8()..=b.u8()).map(|x| unsafe { RoomCoordinate::unchecked_new(x) })
 }
 
-/// Iterate over the range of `RoomCoordinates`s from `a` to `b`, excluding both endpoints.
+/// Iterate over the range of [`RoomCoordinates`]s from `a` to `b`, excluding both endpoints.
 ///
-/// Safe to call even when a >= b, will just yield an empty range.
+/// Safe to call even when `a >= b`, will just yield an empty range.
 ///
 /// # Example
 ///

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -43,16 +43,13 @@ impl Iterator for PairIter {
         if self.forward == self.backward {
             self.done = true;
         } else if self.forward.1 == self.b_max {
-            // SAFETY: self.backward.1 <= self.b_max, so
-            // self.forward.0 < self.backward.0, meaning we can
-            // increment by 1.
+            // SAFETY: self.backward.1 <= self.b_max, so self.forward.0 < self.backward.0, meaning we can increment by 1.
             self.forward = (
                 unsafe { RoomCoordinate::unchecked_new(self.forward.0.u8() + 1) },
                 self.b_min,
             );
         } else {
-            // SAFETY: self.forward.1 < self.b_max, so we can step
-            // up by 1.
+            // SAFETY: self.forward.1 < self.b_max, so we can step up by 1.
             self.forward.1 = unsafe { RoomCoordinate::unchecked_new(self.forward.1.u8() + 1) };
         }
 
@@ -139,16 +136,13 @@ impl DoubleEndedIterator for PairIter {
         if self.backward == self.forward {
             self.done = true;
         } else if self.backward.1 == self.b_min {
-            // SAFETY: self.forward.1 >= self.b_min, so
-            // self.forward.0 < self.backward.0, meaning we can
-            // decrement by 1.
+            // SAFETY: self.forward.1 >= self.b_min, so self.forward.0 < self.backward.0, meaning we can decrement by 1.
             self.backward = (
                 unsafe { RoomCoordinate::unchecked_new(self.backward.0.u8() - 1) },
                 self.b_max,
             );
         } else {
-            // SAFETY: self.backward.1 > self.b_min, so we can step
-            // down by 1.
+            // SAFETY: self.backward.1 > self.b_min, so we can step down by 1.
             self.backward.1 = unsafe { RoomCoordinate::unchecked_new(self.backward.1.u8() - 1) };
         }
 
@@ -198,7 +192,7 @@ impl DoubleEndedIterator for PairIter {
 }
 
 /// An enum for controlling the iteration order of a [`GridIter`]. Thinking of a [`GridIter`]
-/// as a nested for-loop, XMajor would correspond to
+/// as a nested for-loop, `XMajor` would correspond to
 ///
 /// ```
 /// for x in 0..=10 {
@@ -208,7 +202,7 @@ impl DoubleEndedIterator for PairIter {
 /// }
 /// ```
 ///
-/// whereas YMajor would coorespond to
+/// whereas `YMajor` would coorespond to
 ///
 /// ```
 /// for y in 0..=10 {

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -185,7 +185,7 @@ impl DoubleEndedIterator for PairIter {
             },
         );
 
-        range_inclusive(self.forward.0, self.b_max)
+        range_inclusive(self.forward.1, self.b_max)
             .map(|b| (self.forward.0, b))
             .rfold(middle_partials_acc, f)
     }
@@ -604,6 +604,53 @@ mod test {
                 v
             },
         );
+        assert_eq!(expected.as_slice(), actual);
+    }
+
+    #[test]
+    fn test_grid_iter_single_row_fold() {
+        let mut base_iter = GridIter::new(make_xy(0, 0), make_xy(0, 10), Order::XMajor);
+        base_iter.next().unwrap();
+        base_iter.next_back().unwrap();
+        let expected: Vec<_> = (1..=9).map(|y| make_xy(0, y)).collect();
+        let actual = base_iter.clone().fold(Vec::new(), |mut v, xy| {
+            v.push(xy);
+            v
+        });
+        assert_eq!(expected, actual);
+
+        let expected: Vec<_> = (1..=9).rev().map(|y| make_xy(0, y)).collect();
+        let actual = base_iter.rfold(Vec::new(), |mut v, xy| {
+            v.push(xy);
+            v
+        });
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_grid_iter_fold_general_case() {
+        let mut base_iter = GridIter::new(make_xy(0, 0), make_xy(3, 1), Order::XMajor);
+        base_iter.next().unwrap();
+        base_iter.next_back().unwrap();
+        let mut expected = [
+            make_xy(0, 1),
+            make_xy(1, 0),
+            make_xy(1, 1),
+            make_xy(2, 0),
+            make_xy(2, 1),
+            make_xy(3, 0),
+        ];
+        let actual = base_iter.clone().fold(Vec::new(), |mut v, xy| {
+            v.push(xy);
+            v
+        });
+        assert_eq!(expected.as_slice(), actual);
+
+        expected.reverse();
+        let actual = base_iter.rfold(Vec::new(), |mut v, xy| {
+            v.push(xy);
+            v
+        });
         assert_eq!(expected.as_slice(), actual);
     }
 }

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -1,6 +1,185 @@
 use std::iter::FusedIterator;
 
-use screeps::{Room, RoomCoordinate, RoomXY};
+use screeps::{RoomCoordinate, RoomXY};
+
+use crate::room_coordinate::{range_exclusive, range_inclusive};
+
+#[derive(Debug, Clone)]
+struct PairIter {
+    // SAFETY INVARIANT: forward.1 and backward.1 are within
+    // b_min..=b_max at all times
+    b_min: RoomCoordinate,
+    b_max: RoomCoordinate,
+    // SAFETY INVARIANT: forward <= backward at all times
+    forward: (RoomCoordinate, RoomCoordinate),
+    backward: (RoomCoordinate, RoomCoordinate),
+    done: bool,
+}
+
+impl PairIter {
+    fn new(min: (RoomCoordinate, RoomCoordinate), max: (RoomCoordinate, RoomCoordinate)) -> Self {
+        Self {
+            b_min: min.1,
+            b_max: max.1,
+            forward: min,
+            backward: max,
+            done: max.0 < min.0 || max.1 < min.1,
+        }
+    }
+}
+
+impl Iterator for PairIter {
+    type Item = (RoomCoordinate, RoomCoordinate);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let res = Some(self.forward);
+
+        if self.forward == self.backward {
+            self.done = true;
+        } else if self.forward.1 == self.b_max {
+            // SAFETY: self.backward.1 <= self.b_max, so
+            // self.forward.0 < self.backward.0, meaning we can
+            // increment by 1.
+            self.forward = (
+                unsafe { RoomCoordinate::unchecked_new(self.forward.0.u8() + 1) },
+                self.b_min,
+            );
+        } else {
+            // SAFETY: self.forward.1 < self.b_max, so we can step
+            // up by 1.
+            self.forward.1 = unsafe { RoomCoordinate::unchecked_new(self.forward.1.u8() + 1) };
+        }
+
+        res
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        if self.done {
+            return init;
+        }
+
+        if self.forward.0 == self.backward.0 {
+            return range_inclusive(self.forward.1, self.backward.1)
+                .map(|b| (self.forward.0, b))
+                .fold(init, f);
+        }
+
+        let forward_partial_acc = range_inclusive(self.forward.1, self.b_max)
+            .map(|b| (self.forward.0, b))
+            .fold(init, &mut f);
+
+        let middle_partials_acc = range_exclusive(
+            unsafe { RoomCoordinate::unchecked_new(self.forward.0.u8() + 1) },
+            self.backward.0,
+        )
+        .fold(forward_partial_acc, |inner_acc, a| {
+            range_inclusive(self.b_min, self.b_max)
+                .map(|b| (a, b))
+                .fold(inner_acc, &mut f)
+        });
+
+        range_inclusive(self.b_min, self.backward.1)
+            .map(|b| (self.backward.0, b))
+            .fold(middle_partials_acc, f)
+    }
+}
+
+impl FusedIterator for PairIter {}
+
+impl ExactSizeIterator for PairIter {
+    fn len(&self) -> usize {
+        if self.done {
+            return 0;
+        }
+
+        let forward = (self.forward.0.u8(), self.forward.1.u8());
+        let backward = (self.backward.0.u8(), self.backward.1.u8());
+
+        if forward.0 == backward.0 {
+            return (backward.1 - forward.1 + 1) as usize;
+        }
+
+        let full_ranges = (backward.0 - forward.0 - 1) as usize;
+        full_ranges * (self.b_max.u8() - self.b_min.u8() + 1) as usize
+            + (self.b_max.u8() - forward.1 + 1) as usize
+            + (backward.1 - self.b_min.u8() + 1) as usize
+    }
+}
+
+impl DoubleEndedIterator for PairIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let res = Some(self.backward);
+
+        if self.backward == self.forward {
+            self.done = true;
+        } else if self.backward.1 == self.b_min {
+            // SAFETY: self.forward.1 >= self.b_min, so
+            // self.forward.0 < self.backward.0, meaning we can
+            // decrement by 1.
+            self.backward = (
+                unsafe { RoomCoordinate::unchecked_new(self.backward.0.u8() + 1) },
+                self.b_max,
+            );
+        } else {
+            // SAFETY: self.backward.1 > self.b_min, so we can step
+            // down by 1.
+            self.backward.1 = unsafe { RoomCoordinate::unchecked_new(self.backward.1.u8() + 1) };
+        }
+
+        res
+    }
+
+    fn rfold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        if self.done {
+            return init;
+        }
+
+        if self.forward.0 == self.backward.0 {
+            return range_inclusive(self.forward.1, self.backward.1)
+                .map(|b| (self.forward.0, b))
+                .rfold(init, f);
+        }
+
+        let backward_partial_acc = range_inclusive(self.b_min, self.backward.1)
+            .map(|b| (self.backward.0, b))
+            .rfold(init, &mut f);
+
+        let middle_partials_acc = range_exclusive(
+            unsafe { RoomCoordinate::unchecked_new(self.forward.0.u8() + 1) },
+            self.backward.0,
+        )
+        .rfold(backward_partial_acc, |inner_acc, a| {
+            range_inclusive(self.b_min, self.b_max)
+                .map(|b| (a, b))
+                .rfold(inner_acc, &mut f)
+        });
+
+        range_inclusive(self.forward.0, self.b_max)
+            .map(|b| (self.forward.0, b))
+            .rfold(middle_partials_acc, f)
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Order {
@@ -8,33 +187,25 @@ pub enum Order {
     RowMajor,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GridIter {
-    b_min: u8,
-    b_max: u8,
-    forward: (u8, u8),
-    backward: (u8, u8),
+    inner: PairIter,
     order: Order,
-    done: bool,
 }
 
 impl GridIter {
     pub fn new(top_left: RoomXY, bottom_right: RoomXY, order: Order) -> Self {
-        let top = top_left.y.u8();
-        let bottom = bottom_right.y.u8();
-        let left = top_left.x.u8();
-        let right = bottom_right.x.u8();
+        let top = top_left.y;
+        let bottom = bottom_right.y;
+        let left = top_left.x;
+        let right = bottom_right.x;
         let (a_min, a_max, b_min, b_max) = match order {
             Order::ColumnMajor => (left, right, top, bottom),
             Order::RowMajor => (top, bottom, left, right),
         };
         Self {
-            b_min,
-            b_max,
-            forward: (a_min, b_min),
-            backward: (a_max, b_max),
+            inner: PairIter::new((a_min, b_min), (a_max, b_max)),
             order,
-            done: top > bottom || left > right,
         }
     }
 
@@ -50,34 +221,11 @@ impl Iterator for GridIter {
     type Item = RoomXY;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-
-        // SAFETY: self.forward will always be a value in the range
-        // (a_min..=a_max, self.b_min..=self.b_max), which were
-        // obtained from existing RoomXY values passed in Self::new.
-        let res = unsafe {
-            Some(self.get_xy(
-                RoomCoordinate::unchecked_new(self.forward.0),
-                RoomCoordinate::unchecked_new(self.forward.1),
-            ))
-        };
-
-        if self.forward == self.backward {
-            self.done = true;
-        } else if self.forward.1 == self.b_max {
-            self.forward = (self.forward.0 + 1, self.b_min);
-        } else {
-            self.forward.1 += 1;
-        }
-
-        res
+        self.inner.next().map(|(a, b)| self.get_xy(a, b))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len();
-        return (len, Some(len));
+        self.inner.size_hint()
     }
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
@@ -85,76 +233,13 @@ impl Iterator for GridIter {
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        // SAFETY for all RoomCoordinate::unchecked_new usages:
-        // All the passed in u8 values are derived from forward, backward,
-        // b_min, or b_max. Forward and backward will always be in the range
-        // (a_min..=a_max, b_min..=b_max) established in Self::new, and all
-        // four of those come directly from existing RoomXY instances.
-        if self.done {
-            return init;
-        }
-
-        let a = unsafe { RoomCoordinate::unchecked_new(self.forward.0) };
-
-        if self.forward.0 == self.backward.0 {
-            return (self.forward.1..=self.backward.1)
-                .map(|b| self.get_xy(a, unsafe { RoomCoordinate::unchecked_new(b) }))
-                .fold(init, f);
-        }
-
         match self.order {
-            Order::ColumnMajor => {
-                let first_column_acc = {
-                    let x = a;
-                    (self.forward.1..=self.b_max)
-                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                        .map(|y| RoomXY { x, y })
-                        .fold(init, &mut f)
-                };
-
-                let middle_columns_acc = (self.forward.0 + 1..self.backward.0)
-                    .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                    .fold(first_column_acc, |inner_acc, x| {
-                        (self.b_min..=self.b_max)
-                            .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                            .map(|y| RoomXY { x, y })
-                            .fold(inner_acc, &mut f)
-                    });
-
-                {
-                    let x = unsafe { RoomCoordinate::unchecked_new(self.backward.0) };
-                    (self.b_min..=self.backward.1)
-                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                        .map(|y| RoomXY { x, y })
-                        .fold(middle_columns_acc, f)
-                }
-            }
-            Order::RowMajor => {
-                let first_row_acc = {
-                    let y = a;
-                    (self.forward.1..=self.b_max)
-                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                        .map(|x| RoomXY { x, y })
-                        .fold(init, &mut f)
-                };
-
-                let middle_rows_acc = (self.forward.0 + 1..self.backward.0)
-                    .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                    .fold(first_row_acc, |inner_acc, y| {
-                        (self.b_min..=self.b_max)
-                            .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                            .map(|x| RoomXY { x, y })
-                            .fold(inner_acc, &mut f)
-                    });
-
-                {
-                    let y = unsafe { RoomCoordinate::unchecked_new(self.backward.0) };
-                    (self.b_min..=self.backward.1)
-                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                        .map(|x| RoomXY { x, y })
-                        .fold(middle_rows_acc, f)
-                }
-            }
+            Order::ColumnMajor => self
+                .inner
+                .fold(init, move |acc, (x, y)| f(acc, RoomXY { x, y })),
+            Order::RowMajor => self
+                .inner
+                .fold(init, move |acc, (y, x)| f(acc, RoomXY { x, y })),
         }
     }
 }
@@ -163,123 +248,27 @@ impl FusedIterator for GridIter {}
 
 impl ExactSizeIterator for GridIter {
     fn len(&self) -> usize {
-        if self.done {
-            return 0;
-        }
-
-        if self.forward.0 == self.backward.0 {
-            return (self.backward.1 - self.forward.1 + 1) as usize;
-        }
-
-        let full_ranges = (self.backward.0 - self.forward.0 - 1) as usize;
-        full_ranges * (self.b_max - self.b_min + 1) as usize
-            + (self.b_max - self.forward.1 + 1) as usize
-            + (self.backward.1 - self.b_min + 1) as usize
+        self.inner.len()
     }
 }
 
 impl DoubleEndedIterator for GridIter {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-
-        // SAFETY: self.backward will always be a value in the range
-        // (a_min..=a_max, self.b_min..=self.b_max), which were
-        // obtained from existing RoomXY values passed in Self::new.
-        let res = unsafe {
-            Some(self.get_xy(
-                RoomCoordinate::unchecked_new(self.backward.0),
-                RoomCoordinate::unchecked_new(self.backward.1),
-            ))
-        };
-
-        if self.backward == self.forward {
-            self.done = true;
-        } else if self.backward.1 == self.b_min {
-            self.backward = (self.backward.0 - 1, self.b_max);
-        } else {
-            self.backward.1 -= 1;
-        }
-
-        res
+        self.inner.next_back().map(|(a, b)| self.get_xy(a, b))
     }
 
-    fn rfold<B, F>(self, init: B, mut f: F) -> B
+    fn rfold<B, F>(mut self, init: B, mut f: F) -> B
     where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        // SAFETY for all RoomCoordinate::unchecked_new usages:
-        // All the passed in u8 values are derived from forward, backward,
-        // b_min, or b_max. Forward and backward will always be in the range
-        // (a_min..=a_max, b_min..=b_max) established in Self::new, and all
-        // four of those come directly from existing RoomXY instances.
-        if self.done {
-            return init;
-        }
-
-        let a = unsafe { RoomCoordinate::unchecked_new(self.backward.0) };
-
-        if self.backward.0 == self.forward.0 {
-            return (self.forward.1..=self.backward.1)
-                .map(|b| self.get_xy(a, unsafe { RoomCoordinate::unchecked_new(b) }))
-                .rfold(init, f);
-        }
-
         match self.order {
-            Order::ColumnMajor => {
-                let last_column_acc = {
-                    let x = a;
-                    (self.b_min..=self.backward.1)
-                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                        .map(|y| RoomXY { x, y })
-                        .rfold(init, &mut f)
-                };
-
-                let middle_columns_acc = (self.forward.0 + 1..self.backward.0)
-                    .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                    .rfold(last_column_acc, |inner_acc, x| {
-                        (self.b_min..=self.b_max)
-                            .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                            .map(|y| RoomXY { x, y })
-                            .rfold(inner_acc, &mut f)
-                    });
-
-                {
-                    let x = unsafe { RoomCoordinate::unchecked_new(self.forward.0) };
-                    (self.forward.1..=self.b_max)
-                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                        .map(|y| RoomXY { x, y })
-                        .rfold(middle_columns_acc, f)
-                }
-            }
-            Order::RowMajor => {
-                let last_row_acc = {
-                    let y = a;
-                    (self.b_min..=self.backward.1)
-                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                        .map(|x| RoomXY { x, y })
-                        .rfold(init, &mut f)
-                };
-
-                let middle_rows_acc = (self.forward.0 + 1..self.backward.0)
-                    .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
-                    .rfold(last_row_acc, |inner_acc, y| {
-                        (self.b_min..=self.b_max)
-                            .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                            .map(|x| RoomXY { x, y })
-                            .rfold(inner_acc, &mut f)
-                    });
-
-                {
-                    let y = unsafe { RoomCoordinate::unchecked_new(self.forward.0) };
-                    (self.forward.1..=self.b_max)
-                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
-                        .map(|x| RoomXY { x, y })
-                        .rfold(middle_rows_acc, f)
-                }
-            }
+            Order::ColumnMajor => self
+                .inner
+                .rfold(init, move |acc, (x, y)| f(acc, RoomXY { x, y })),
+            Order::RowMajor => self
+                .inner
+                .rfold(init, move |acc, (y, x)| f(acc, RoomXY { x, y })),
         }
     }
 }

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -183,8 +183,8 @@ impl DoubleEndedIterator for PairIter {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Order {
-    ColumnMajor,
-    RowMajor,
+    XMajor,
+    YMajor,
 }
 
 #[derive(Debug, Clone)]
@@ -200,8 +200,8 @@ impl GridIter {
         let left = top_left.x;
         let right = bottom_right.x;
         let (a_min, a_max, b_min, b_max) = match order {
-            Order::ColumnMajor => (left, right, top, bottom),
-            Order::RowMajor => (top, bottom, left, right),
+            Order::XMajor => (left, right, top, bottom),
+            Order::YMajor => (top, bottom, left, right),
         };
         Self {
             inner: PairIter::new((a_min, b_min), (a_max, b_max)),
@@ -211,8 +211,8 @@ impl GridIter {
 
     fn get_xy(&self, a: RoomCoordinate, b: RoomCoordinate) -> RoomXY {
         match self.order {
-            Order::ColumnMajor => RoomXY { x: a, y: b },
-            Order::RowMajor => RoomXY { x: b, y: a },
+            Order::XMajor => RoomXY { x: a, y: b },
+            Order::YMajor => RoomXY { x: b, y: a },
         }
     }
 }
@@ -234,10 +234,10 @@ impl Iterator for GridIter {
         F: FnMut(B, Self::Item) -> B,
     {
         match self.order {
-            Order::ColumnMajor => self
+            Order::XMajor => self
                 .inner
                 .fold(init, move |acc, (x, y)| f(acc, RoomXY { x, y })),
-            Order::RowMajor => self
+            Order::YMajor => self
                 .inner
                 .fold(init, move |acc, (y, x)| f(acc, RoomXY { x, y })),
         }
@@ -263,10 +263,10 @@ impl DoubleEndedIterator for GridIter {
         F: FnMut(B, Self::Item) -> B,
     {
         match self.order {
-            Order::ColumnMajor => self
+            Order::XMajor => self
                 .inner
                 .rfold(init, move |acc, (x, y)| f(acc, RoomXY { x, y })),
-            Order::RowMajor => self
+            Order::YMajor => self
                 .inner
                 .rfold(init, move |acc, (y, x)| f(acc, RoomXY { x, y })),
         }
@@ -287,7 +287,7 @@ pub fn chebyshev_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = 
         x: centre.x.saturating_add(signed_radius),
         y: centre.y.saturating_add(signed_radius),
     };
-    GridIter::new(top_left, bottom_right, Order::RowMajor)
+    GridIter::new(top_left, bottom_right, Order::YMajor)
 }
 
 pub fn manhattan_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = RoomXY> {

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -134,7 +134,7 @@ impl DoubleEndedIterator for PairIter {
             // self.forward.0 < self.backward.0, meaning we can
             // decrement by 1.
             self.backward = (
-                unsafe { RoomCoordinate::unchecked_new(self.backward.0.u8() + 1) },
+                unsafe { RoomCoordinate::unchecked_new(self.backward.0.u8() - 1) },
                 self.b_max,
             );
         } else {

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -4,7 +4,8 @@ use screeps::{RoomCoordinate, RoomXY};
 
 use crate::room_coordinate::{range_exclusive, range_inclusive};
 
-// An iterator over ordered pairs of RoomCoordinates; first coordinate is the major axis.
+// An iterator over ordered pairs of RoomCoordinates; first coordinate is the
+// major axis.
 #[derive(Debug, Clone)]
 struct PairIter {
     // SAFETY INVARIANT: forward.1 and backward.1 are within b_min..=b_max when !done
@@ -43,7 +44,8 @@ impl Iterator for PairIter {
         if self.forward == self.backward {
             self.done = true;
         } else if self.forward.1 == self.b_max {
-            // SAFETY: self.backward.1 <= self.b_max, so self.forward.0 < self.backward.0, meaning we can increment by 1.
+            // SAFETY: self.backward.1 <= self.b_max, so self.forward.0 < self.backward.0,
+            // meaning we can increment by 1.
             self.forward = (
                 unsafe { RoomCoordinate::unchecked_new(self.forward.0.u8() + 1) },
                 self.b_min,
@@ -145,7 +147,8 @@ impl DoubleEndedIterator for PairIter {
         if self.backward == self.forward {
             self.done = true;
         } else if self.backward.1 == self.b_min {
-            // SAFETY: self.forward.1 >= self.b_min, so self.forward.0 < self.backward.0, meaning we can decrement by 1.
+            // SAFETY: self.forward.1 >= self.b_min, so self.forward.0 < self.backward.0,
+            // meaning we can decrement by 1.
             self.backward = (
                 unsafe { RoomCoordinate::unchecked_new(self.backward.0.u8() - 1) },
                 self.b_max,
@@ -209,8 +212,8 @@ impl DoubleEndedIterator for PairIter {
     }
 }
 
-/// An enum for controlling the iteration order of a [`GridIter`]. Thinking of a [`GridIter`]
-/// as a nested for-loop, `XMajor` would correspond to
+/// An enum for controlling the iteration order of a [`GridIter`]. Thinking of a
+/// [`GridIter`] as a nested for-loop, `XMajor` would correspond to
 ///
 /// ```
 /// for x in 0..=10 {
@@ -243,18 +246,19 @@ pub struct GridIter {
 }
 
 impl GridIter {
-    /// Creates a `GridIter` over the rectangular grid of `RoomXY` specified by the top-left
-    /// and bottom-right corners provided. Will determine whether to iterate `x` or `y` first
-    /// using the passed-in [`Order`].
+    /// Creates a `GridIter` over the rectangular grid of `RoomXY` specified by
+    /// the top-left and bottom-right corners provided. Will determine
+    /// whether to iterate `x` or `y` first using the passed-in [`Order`].
     ///
-    /// It is safe to pass in invalid corner specifications (e.g. `top_left.x > bottom_right.x`),
-    /// the returned `GridIter` will be immediately completed.
+    /// It is safe to pass in invalid corner specifications (e.g. `top_left.x >
+    /// bottom_right.x`), the returned `GridIter` will be immediately
+    /// completed.
     ///
     /// # Example
     ///
     /// ```
+    /// use screeps::local::{RoomCoordinate, RoomXY};
     /// use screeps_utils::room_xy::{GridIter, Order};
-    /// use screeps::local::{RoomXY, RoomCoordinate};
     ///
     /// for xy in GridIter::new(
     ///     RoomXY {
@@ -265,7 +269,7 @@ impl GridIter {
     ///         x: RoomCoordinate::new(1).unwrap(),
     ///         y: RoomCoordinate::new(2).unwrap(),
     ///     },
-    ///     Order::XMajor
+    ///     Order::XMajor,
     /// ) {
     ///     // Will print (x: 0, y: 0), then (x: 0, y: 1), (x: 0, y: 2), (x: 1, y: 0), etc.
     ///     println!("{:?}", xy);
@@ -350,14 +354,15 @@ impl DoubleEndedIterator for GridIter {
     }
 }
 
-/// Creates an iterator over all [`RoomXY`] around the designated centre (including the centre)
-/// within the given [Chebyshev distance](https://en.wikipedia.org/wiki/Chebyshev_distance).
-/// This is the same distance measure used for attack ranges, or for road lengths between two points, etc.
+/// Creates an iterator over all [`RoomXY`] around the designated centre
+/// (including the centre) within the given [Chebyshev distance](https://en.wikipedia.org/wiki/Chebyshev_distance).
+/// This is the same distance measure used for attack ranges, or for road
+/// lengths between two points, etc.
 ///
 /// # Iteration order
 ///
-/// The order over which points are iterated within the range is unspecified, and may change
-/// at any time.
+/// The order over which points are iterated within the range is unspecified,
+/// and may change at any time.
 pub fn chebyshev_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = RoomXY> {
     let signed_radius = radius.min(50) as i8;
     let top_left = RoomXY {
@@ -371,14 +376,15 @@ pub fn chebyshev_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = 
     GridIter::new(top_left, bottom_right, Order::YMajor)
 }
 
-/// Creates an iterator over all [`RoomXY`] around the designated centre (including the centre)
-/// within the given [Manhattan distance](https://en.wikipedia.org/wiki/Taxicab_geometry).
-/// This would be used for, e.g., measuring the number of walls needed between 2 points.
+/// Creates an iterator over all [`RoomXY`] around the designated centre
+/// (including the centre) within the given [Manhattan distance](https://en.wikipedia.org/wiki/Taxicab_geometry).
+/// This would be used for, e.g., measuring the number of walls needed between 2
+/// points.
 ///
 /// # Iteration order
 ///
-/// The order over which points are iterated within the range is unspecified, and may change
-/// at any time.
+/// The order over which points are iterated within the range is unspecified,
+/// and may change at any time.
 pub fn manhattan_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = RoomXY> {
     let signed_radius = radius.min(100) as i8;
     let min_x = centre.x.saturating_add(-signed_radius);

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -279,13 +279,15 @@ pub fn grid_iter(top_left: RoomXY, bottom_right: RoomXY, order: Order) -> GridIt
 
 pub fn chebyshev_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = RoomXY> {
     let signed_radius = radius.min(50) as i8;
-    (-signed_radius..=signed_radius)
-        .filter_map(move |x| centre.x.checked_add(x))
-        .flat_map(move |x| {
-            (-signed_radius..=signed_radius)
-                .filter_map(move |y| centre.y.checked_add(y))
-                .map(move |y| RoomXY { x, y })
-        })
+    let top_left = RoomXY {
+        x: centre.x.saturating_add(-signed_radius),
+        y: centre.y.saturating_add(-signed_radius)
+    };
+    let bottom_right = RoomXY {
+        x: centre.x.saturating_add(signed_radius),
+        y: centre.y.saturating_add(signed_radius)
+    };
+    GridIter::new(top_left, bottom_right, Order::RowMajor)
 }
 
 pub fn manhattan_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = RoomXY> {

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -486,7 +486,7 @@ mod test {
     }
 
     #[test]
-    fn test_grid_xmajor() {
+    fn test_grid_iter_basic() {
         let mut iter = GridIter::new(make_xy(0, 0), make_xy(1, 1), Order::XMajor);
         assert_eq!(make_xy(0, 0), iter.next().unwrap());
         assert_eq!(make_xy(0, 1), iter.next().unwrap());
@@ -517,5 +517,99 @@ mod test {
         assert_eq!(make_xy(1, 0), iter.next_back().unwrap());
         assert_eq!(make_xy(0, 0), iter.next_back().unwrap());
         assert_eq!(None, iter.next_back());
+    }
+
+    #[test]
+    fn test_grid_iter_len() {
+        let mut iter = GridIter::new(make_xy(0, 0), make_xy(2, 1), Order::XMajor);
+        for i in (1..=6).rev() {
+            assert_eq!(iter.len(), i);
+            iter.next().unwrap();
+        }
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.next(), None);
+
+        iter = GridIter::new(make_xy(0, 0), make_xy(2, 1), Order::XMajor);
+        for i in (1..=6).rev() {
+            assert_eq!(iter.len(), i);
+            iter.next_back().unwrap();
+        }
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.next_back(), None);
+    }
+
+    #[test]
+    fn test_grid_iter_bad_corners() {
+        let mut iter = GridIter::new(make_xy(10, 10), make_xy(10, 9), Order::XMajor);
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.next(), None);
+
+        iter = GridIter::new(make_xy(10, 10), make_xy(9, 10), Order::XMajor);
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.next(), None);
+
+        iter = GridIter::new(make_xy(10, 10), make_xy(9, 9), Order::XMajor);
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_grid_iter_single_square() {
+        let coords: Vec<_> =
+            GridIter::new(make_xy(25, 25), make_xy(25, 25), Order::XMajor).collect();
+        assert_eq!(coords, [make_xy(25, 25)]);
+    }
+
+    #[test]
+    fn test_grid_iter_mixing_forward_and_back() {
+        let mut iter = GridIter::new(make_xy(0, 0), make_xy(2, 1), Order::XMajor);
+        assert_eq!(iter.next().unwrap(), make_xy(0, 0));
+        assert_eq!(iter.next_back().unwrap(), make_xy(2, 1));
+        assert_eq!(iter.next_back().unwrap(), make_xy(2, 0));
+        assert_eq!(iter.next().unwrap(), make_xy(0, 1));
+        assert_eq!(iter.next().unwrap(), make_xy(1, 0));
+        assert_eq!(iter.next_back().unwrap(), make_xy(1, 1));
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_grid_iter_fold() {
+        let expected = [
+            make_xy(0, 0),
+            make_xy(0, 1),
+            make_xy(0, 2),
+            make_xy(1, 0),
+            make_xy(1, 1),
+            make_xy(1, 2),
+        ];
+        let actual = GridIter::new(make_xy(0, 0), make_xy(1, 2), Order::XMajor).fold(
+            Vec::new(),
+            |mut v, xy| {
+                v.push(xy);
+                v
+            },
+        );
+        assert_eq!(expected.as_slice(), actual);
+    }
+
+    #[test]
+    fn test_grid_iter_rfold() {
+        let expected = [
+            make_xy(1, 2),
+            make_xy(0, 2),
+            make_xy(1, 1),
+            make_xy(0, 1),
+            make_xy(1, 0),
+            make_xy(0, 0),
+        ];
+        let actual = GridIter::new(make_xy(0, 0), make_xy(1, 2), Order::YMajor).rfold(
+            Vec::new(),
+            |mut v, xy| {
+                v.push(xy);
+                v
+            },
+        );
+        assert_eq!(expected.as_slice(), actual);
     }
 }

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -140,7 +140,7 @@ impl DoubleEndedIterator for PairIter {
         } else {
             // SAFETY: self.backward.1 > self.b_min, so we can step
             // down by 1.
-            self.backward.1 = unsafe { RoomCoordinate::unchecked_new(self.backward.1.u8() + 1) };
+            self.backward.1 = unsafe { RoomCoordinate::unchecked_new(self.backward.1.u8() - 1) };
         }
 
         res

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -1,0 +1,317 @@
+use std::iter::FusedIterator;
+
+use screeps::{Room, RoomCoordinate, RoomXY};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Order {
+    ColumnMajor,
+    RowMajor,
+}
+
+#[derive(Debug)]
+pub struct GridIter {
+    b_min: u8,
+    b_max: u8,
+    forward: (u8, u8),
+    backward: (u8, u8),
+    order: Order,
+    done: bool,
+}
+
+impl GridIter {
+    pub fn new(top_left: RoomXY, bottom_right: RoomXY, order: Order) -> Self {
+        let top = top_left.y.u8();
+        let bottom = bottom_right.y.u8();
+        let left = top_left.x.u8();
+        let right = bottom_right.x.u8();
+        let (a_min, a_max, b_min, b_max) = match order {
+            Order::ColumnMajor => (left, right, top, bottom),
+            Order::RowMajor => (top, bottom, left, right),
+        };
+        Self {
+            b_min,
+            b_max,
+            forward: (a_min, b_min),
+            backward: (a_max, b_max),
+            order,
+            done: top > bottom || left > right,
+        }
+    }
+
+    fn get_xy(&self, a: RoomCoordinate, b: RoomCoordinate) -> RoomXY {
+        match self.order {
+            Order::ColumnMajor => RoomXY { x: a, y: b },
+            Order::RowMajor => RoomXY { x: b, y: a },
+        }
+    }
+}
+
+impl Iterator for GridIter {
+    type Item = RoomXY;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        // SAFETY: self.forward will always be a value in the range
+        // (a_min..=a_max, self.b_min..=self.b_max), which were
+        // obtained from existing RoomXY values passed in Self::new.
+        let res = unsafe {
+            Some(self.get_xy(
+                RoomCoordinate::unchecked_new(self.forward.0),
+                RoomCoordinate::unchecked_new(self.forward.1),
+            ))
+        };
+
+        if self.forward == self.backward {
+            self.done = true;
+        } else if self.forward.1 == self.b_max {
+            self.forward = (self.forward.0 + 1, self.b_min);
+        } else {
+            self.forward.1 += 1;
+        }
+
+        res
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        return (len, Some(len));
+    }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // SAFETY for all RoomCoordinate::unchecked_new usages:
+        // All the passed in u8 values are derived from forward, backward,
+        // b_min, or b_max. Forward and backward will always be in the range
+        // (a_min..=a_max, b_min..=b_max) established in Self::new, and all
+        // four of those come directly from existing RoomXY instances.
+        if self.done {
+            return init;
+        }
+
+        let a = unsafe { RoomCoordinate::unchecked_new(self.forward.0) };
+
+        if self.forward.0 == self.backward.0 {
+            return (self.forward.1..=self.backward.1)
+                .map(|b| self.get_xy(a, unsafe { RoomCoordinate::unchecked_new(b) }))
+                .fold(init, f);
+        }
+
+        match self.order {
+            Order::ColumnMajor => {
+                let first_column_acc = {
+                    let x = a;
+                    (self.forward.1..=self.b_max)
+                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                        .map(|y| RoomXY { x, y })
+                        .fold(init, &mut f)
+                };
+
+                let middle_columns_acc = (self.forward.0 + 1..self.backward.0)
+                    .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                    .fold(first_column_acc, |inner_acc, x| {
+                        (self.b_min..=self.b_max)
+                            .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                            .map(|y| RoomXY { x, y })
+                            .fold(inner_acc, &mut f)
+                    });
+
+                {
+                    let x = unsafe { RoomCoordinate::unchecked_new(self.backward.0) };
+                    (self.b_min..=self.backward.1)
+                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                        .map(|y| RoomXY { x, y })
+                        .fold(middle_columns_acc, f)
+                }
+            }
+            Order::RowMajor => {
+                let first_row_acc = {
+                    let y = a;
+                    (self.forward.1..=self.b_max)
+                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                        .map(|x| RoomXY { x, y })
+                        .fold(init, &mut f)
+                };
+
+                let middle_rows_acc = (self.forward.0 + 1..self.backward.0)
+                    .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                    .fold(first_row_acc, |inner_acc, y| {
+                        (self.b_min..=self.b_max)
+                            .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                            .map(|x| RoomXY { x, y })
+                            .fold(inner_acc, &mut f)
+                    });
+
+                {
+                    let y = unsafe { RoomCoordinate::unchecked_new(self.backward.0) };
+                    (self.b_min..=self.backward.1)
+                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                        .map(|x| RoomXY { x, y })
+                        .fold(middle_rows_acc, f)
+                }
+            }
+        }
+    }
+}
+
+impl FusedIterator for GridIter {}
+
+impl ExactSizeIterator for GridIter {
+    fn len(&self) -> usize {
+        if self.done {
+            return 0;
+        }
+
+        if self.forward.0 == self.backward.0 {
+            return (self.backward.1 - self.forward.1 + 1) as usize;
+        }
+
+        let full_ranges = (self.backward.0 - self.forward.0 - 1) as usize;
+        full_ranges * (self.b_max - self.b_min + 1) as usize
+            + (self.b_max - self.forward.1 + 1) as usize
+            + (self.backward.1 - self.b_min + 1) as usize
+    }
+}
+
+impl DoubleEndedIterator for GridIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        // SAFETY: self.backward will always be a value in the range
+        // (a_min..=a_max, self.b_min..=self.b_max), which were
+        // obtained from existing RoomXY values passed in Self::new.
+        let res = unsafe {
+            Some(self.get_xy(
+                RoomCoordinate::unchecked_new(self.backward.0),
+                RoomCoordinate::unchecked_new(self.backward.1),
+            ))
+        };
+
+        if self.backward == self.forward {
+            self.done = true;
+        } else if self.backward.1 == self.b_min {
+            self.backward = (self.backward.0 - 1, self.b_max);
+        } else {
+            self.backward.1 -= 1;
+        }
+
+        res
+    }
+
+    fn rfold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // SAFETY for all RoomCoordinate::unchecked_new usages:
+        // All the passed in u8 values are derived from forward, backward,
+        // b_min, or b_max. Forward and backward will always be in the range
+        // (a_min..=a_max, b_min..=b_max) established in Self::new, and all
+        // four of those come directly from existing RoomXY instances.
+        if self.done {
+            return init;
+        }
+
+        let a = unsafe { RoomCoordinate::unchecked_new(self.backward.0) };
+
+        if self.backward.0 == self.forward.0 {
+            return (self.forward.1..=self.backward.1)
+                .map(|b| self.get_xy(a, unsafe { RoomCoordinate::unchecked_new(b) }))
+                .rfold(init, f);
+        }
+
+        match self.order {
+            Order::ColumnMajor => {
+                let last_column_acc = {
+                    let x = a;
+                    (self.b_min..=self.backward.1)
+                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                        .map(|y| RoomXY { x, y })
+                        .rfold(init, &mut f)
+                };
+
+                let middle_columns_acc = (self.forward.0 + 1..self.backward.0)
+                    .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                    .rfold(last_column_acc, |inner_acc, x| {
+                        (self.b_min..=self.b_max)
+                            .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                            .map(|y| RoomXY { x, y })
+                            .rfold(inner_acc, &mut f)
+                    });
+
+                {
+                    let x = unsafe { RoomCoordinate::unchecked_new(self.forward.0) };
+                    (self.forward.1..=self.b_max)
+                        .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                        .map(|y| RoomXY { x, y })
+                        .rfold(middle_columns_acc, f)
+                }
+            }
+            Order::RowMajor => {
+                let last_row_acc = {
+                    let y = a;
+                    (self.b_min..=self.backward.1)
+                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                        .map(|x| RoomXY { x, y })
+                        .rfold(init, &mut f)
+                };
+
+                let middle_rows_acc = (self.forward.0 + 1..self.backward.0)
+                    .map(|y_raw| unsafe { RoomCoordinate::unchecked_new(y_raw) })
+                    .rfold(last_row_acc, |inner_acc, y| {
+                        (self.b_min..=self.b_max)
+                            .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                            .map(|x| RoomXY { x, y })
+                            .rfold(inner_acc, &mut f)
+                    });
+
+                {
+                    let y = unsafe { RoomCoordinate::unchecked_new(self.forward.0) };
+                    (self.forward.1..=self.b_max)
+                        .map(|x_raw| unsafe { RoomCoordinate::unchecked_new(x_raw) })
+                        .map(|x| RoomXY { x, y })
+                        .rfold(middle_rows_acc, f)
+                }
+            }
+        }
+    }
+}
+
+pub fn grid_iter(top_left: RoomXY, bottom_right: RoomXY, order: Order) -> GridIter {
+    GridIter::new(top_left, bottom_right, order)
+}
+
+pub fn chebyshev_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = RoomXY> {
+    let signed_radius = radius.min(50) as i8;
+    (-signed_radius..=signed_radius)
+        .filter_map(move |x| centre.x.checked_add(x))
+        .flat_map(move |x| {
+            (-signed_radius..=signed_radius)
+                .filter_map(move |y| centre.y.checked_add(y))
+                .map(move |y| RoomXY { x, y })
+        })
+}
+
+pub fn manhattan_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = RoomXY> {
+    let signed_radius = radius.min(100) as i8;
+    (-signed_radius..=signed_radius)
+        .filter_map(move |x| centre.x.checked_add(x).map(|x_coord| (x, x_coord)))
+        .flat_map(move |(x_offset, x)| {
+            let y_range = signed_radius - x_offset.abs();
+            (-y_range..=y_range)
+                .filter_map(move |y| centre.y.checked_add(y))
+                .map(move |y| RoomXY { x, y })
+        })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+}

--- a/src/room_xy.rs
+++ b/src/room_xy.rs
@@ -356,6 +356,7 @@ impl DoubleEndedIterator for GridIter {
 
 /// Creates an iterator over all [`RoomXY`] around the designated centre
 /// (including the centre) within the given [Chebyshev distance](https://en.wikipedia.org/wiki/Chebyshev_distance).
+///
 /// This is the same distance measure used for attack ranges, or for road
 /// lengths between two points, etc.
 ///
@@ -378,6 +379,7 @@ pub fn chebyshev_range_iter(centre: RoomXY, radius: u8) -> impl Iterator<Item = 
 
 /// Creates an iterator over all [`RoomXY`] around the designated centre
 /// (including the centre) within the given [Manhattan distance](https://en.wikipedia.org/wiki/Taxicab_geometry).
+///
 /// This would be used for, e.g., measuring the number of walls needed between 2
 /// points.
 ///


### PR DESCRIPTION
Adds 2 `RoomCoordinate` iterators and 3 `RoomXY` iterators:

- `range_(in/ex)clusive` iterate over `RoomCoordinates`, either including or excluding both endpoints.
- `GridIter` is an `Iterator`-implementing struct that returns all `RoomXY` in a grid of points specified by 2 corners, in either X- or Y-major order.
- `chebyshev_range_iter` iterates over all points within a given Chebyshev distance of the centre point.
- `manhattan_range_iter` iterates over all points within a given Manhattan distance of the centre point.