### PR TITLE
(bugfix) Update offline map data deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ===================
 
 - Updated to 0.23 of screeps-game-api crate
+- Fix offline map deserialization failing on non-integer source and mineral amounts
 
 0.22.1 (2024-09-30)
 ===================

--- a/src/offline_map.rs
+++ b/src/offline_map.rs
@@ -235,7 +235,7 @@ where
             } else {
                 Err(serde::de::Error::custom("Number is not a valid float"))
             }
-        },
+        }
         Value::Null => Ok(0),
         _ => Err(serde::de::Error::custom("Expected a number")),
     }

--- a/src/offline_map.rs
+++ b/src/offline_map.rs
@@ -10,6 +10,8 @@ use serde::{
     Deserialize, Deserializer,
 };
 
+use serde_json::Value;
+
 const ROOM_AREA: usize = (ROOM_SIZE as usize) * (ROOM_SIZE as usize);
 
 #[derive(Clone, Deserialize, Debug)]
@@ -82,6 +84,7 @@ pub enum OfflineObject {
 
         density: Density,
         mineral_type: ResourceType,
+        #[serde(deserialize_with = "deserialize_float_to_u32")]
         mineral_amount: u32,
     },
     #[serde(rename_all = "camelCase")]
@@ -102,6 +105,7 @@ pub enum OfflineObject {
         x: RoomCoordinate,
         y: RoomCoordinate,
 
+        #[serde(deserialize_with = "deserialize_optional_u16")]
         energy: u16,
         energy_capacity: u16,
         ticks_to_regeneration: u16,
@@ -199,6 +203,41 @@ where
             Unexpected::Str(s),
             &"terrain string of correct length",
         ))
+    }
+}
+
+fn deserialize_float_to_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::Number(num) => {
+            if let Some(f) = num.as_f64() {
+                Ok(f as u32) // Convert float to integer, potentially truncating
+            } else {
+                Err(serde::de::Error::custom("Number is not a valid float"))
+            }
+        }
+        _ => Err(serde::de::Error::custom("Expected a number")),
+    }
+}
+
+fn deserialize_optional_u16<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::Number(num) => {
+            if let Some(f) = num.as_u64() {
+                Ok(f as u16)
+            } else {
+                Err(serde::de::Error::custom("Number is not a valid float"))
+            }
+        },
+        Value::Null => Ok(0),
+        _ => Err(serde::de::Error::custom("Expected a number")),
     }
 }
 


### PR DESCRIPTION
The current offline map parsing works for the ScreepsPlus map dumps of shards 1, 2, and 3, but fails for the map dump of shard0. This update specializes the deserialization to functions that handle the edge cases present in the shard0 dataset.